### PR TITLE
Fix: add DSP path for Hamoa

### DIFF
--- a/debian/guess-dsp.sh
+++ b/debian/guess-dsp.sh
@@ -29,6 +29,9 @@ if [ -r /sys/firmware/devicetree/base/model ] ; then
 		*"Robotics RB3gen2"*)
 			DSP_LIBRARY_PATH=/usr/share/qcom/qcm6490/Thundercomm/RB3gen2/dsp
 			;;
+		*"Hamoa IoT EVK"*)
+			DSP_LIBRARY_PATH=/usr/share/qcom/x1e80100/Qualcomm/Hamoa-IoT-EVK/dsp
+			;;
 	esac
 fi
 


### PR DESCRIPTION
Add match pattern "Hamoa IoT EVK" and configure DSP_LIBRARY_PATH. This ensures cdsprpcd/adsprpcd can locate DSP binaries correctly on Hamoa Iot EVK.