### PR TITLE
No change rebuild for migration to Debusine

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fastrpc (1.0.2-1~bpo~qcom2~) UNRELEASED; urgency=medium
+
+  * No change rebuild for migration to Debusine.
+
+ -- Robie Basak <robie.basak@oss.qualcomm.com>  Sun, 03 May 2026 11:51:12 +0100
+
 fastrpc (1.0.2-1~bpo~qcom1) trixie; urgency=medium
 
   * Backport to trixie.


### PR DESCRIPTION
To keep the binaries distinct, bump the version number. If this lands, we can follow the release flow to get this published in the new Debusine-based production QLI apt repository, to join alsa-ucm-conf.